### PR TITLE
#258 show locality when asking a question

### DIFF
--- a/oshot/context_processors.py
+++ b/oshot/context_processors.py
@@ -25,6 +25,8 @@ def forms(request):
             entity = get_object_or_404(Entity, slug=kwargs['entity_slug'])
         elif 'entity_id' in kwargs:
             entity = get_object_or_404(Entity, pk=kwargs['entity_id'])
+        elif request.user.is_authenticated():
+            entity = request.user.profile.locality
 
         context['entity'] = entity
         # where the magic happens: set local or global scope urls


### PR DESCRIPTION
The 'entity' variable was not passed correctly to the context processor
when rendering the post_question form. It was being set in the context
dictionary, but the context processor does not see it - it just sees the
request.
Therefore, I'm saving the entity in the request's session, using it in
the context processor and deleting it from the session (to not interfere
with future browsing when the user may want to look at another
locality).
