### PR TITLE
add --noinput to linux/mac setup instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ Quick Start - Linux
     $ cd open-shot
     $ pip install -r requirements.txt
     $ python manage.py test
-    $ python manage.py syncdb --migrate
+    $ python manage.py syncdb --migrate --noinput
     $ python manage.py runserver
 
 You should now be able to access the site at http://localhost:8000


### PR DESCRIPTION
Simply made it to match the windows installation instructions.
Otherwise you'd get "DatabaseError: no such table: user_profile".
