### PR TITLE
Fix #286: filter multi-word tags correctly

### DIFF
--- a/qa/views.py
+++ b/qa/views.py
@@ -69,7 +69,7 @@ def local_home(request, entity_slug=None, entity_id=None, tags=None,
 
     if tags:
         current_tags = tags.split(',')
-        questions = questions.filter(tags__slug__in=current_tags)
+        questions = questions.filter(tags__name__in=current_tags)
     else:
         current_tags = None
 


### PR DESCRIPTION
Filter by tag name rather than slug, because in the slug whitespace is replaced
by hyphens.
