### PR TITLE
Better fix #286: use tag slugs for URLs, queries

### DIFF
--- a/qa/views.py
+++ b/qa/views.py
@@ -68,8 +68,8 @@ def local_home(request, entity_slug=None, entity_id=None, tags=None,
     questions = questions.order_by(order)
 
     if tags:
-        current_tags = tags.split(',')
-        questions = questions.filter(tags__slug__in=current_tags)
+        current_tags = Tag.objects.filter(slug__in=tags.split(','))
+        questions = questions.filter(tags__in=current_tags)
     else:
         current_tags = None
 

--- a/qa/views.py
+++ b/qa/views.py
@@ -69,7 +69,7 @@ def local_home(request, entity_slug=None, entity_id=None, tags=None,
 
     if tags:
         current_tags = tags.split(',')
-        questions = questions.filter(tags__name__in=current_tags)
+        questions = questions.filter(tags__slug__in=current_tags)
     else:
         current_tags = None
 

--- a/templates/_tags.html
+++ b/templates/_tags.html
@@ -1,9 +1,9 @@
 {% for tag in tags %}
   <li>
   {% if entity %}
-    <a class="btn" href="{% url "show_tags" entity.id tag %}">{{tag}}</a>
+    <a class="btn" href="{% url "show_tags" entity.id tag.slug %}">{{tag}}</a>
   {% else %}
-    <a class="btn" href="{% url "show_tags" tag %}">{{tag}}</a>
+    <a class="btn" href="{% url "show_tags" tag.slug %}">{{tag}}</a>
   {% endif %}
   {% if tag.num_times %}
       × {{tag.num_times}}


### PR DESCRIPTION
Tag names are now only used for display.
