### PR TITLE
Add 'Edit' title in candidate list view for editors

### DIFF
--- a/polyorg/templates/polyorg/candidate_list.html
+++ b/polyorg/templates/polyorg/candidate_list.html
@@ -38,6 +38,7 @@
   {% endfor %}
 </div>
 {% if can_edit %}
+    <h3>{% trans "Edit" %}</h3>
     <p><a href="{% url 'candidate-create' candidatelist.id %}">{% trans "Add candidate" %}</a></p>
     <p><a href="{% url 'candidatelist-edit' candidatelist.id %}">{% trans 'Edit list details' %}</a></p>
 {% endif %}


### PR DESCRIPTION
Separates more clearly the list details from the edit controls.
