### PR TITLE
Fixed Issue #365 (Editing a question removed followers). Added a test.

### DIFF
--- a/qa/views.py
+++ b/qa/views.py
@@ -213,7 +213,7 @@ def post_question(request, entity_id=None, slug=None):
     q = slug and get_object_or_404(Question, unislug=slug, entity=entity)
 
     if request.method == "POST":
-        form = QuestionForm(request.user, request.POST)
+        form = QuestionForm(request.user, request.POST, instance=q)
         if form.is_valid():
             ''' carefull when changing a question's history '''
             if not q:


### PR DESCRIPTION
The problem was that upon edit, the previous instance of the question wasn't fed to the form. Thus, the form's rating was set to 1. The "follows" themselves were still in the database.

I also created a test that fails without the bug fix and passes with it. I'll be happy if you can review the test as well, because some of the code there wasn't intuitive.

Lastly, this is my first contribution to an open source project, so I hope I got everything alright, process-wise.
