### PR TITLE
Separate answer button from other buttons

### DIFF
--- a/qa/templates/qa/_question.html
+++ b/qa/templates/qa/_question.html
@@ -20,6 +20,17 @@
           <div>{% trans "votes" %}</div>
       </div>
     </div>
+    {% if can_answer %}
+    <div class="cp">
+      <a class="btn btn-success btn-large" href="#add_answer_modal" data-toggle="modal">
+        {% if my_answer_form.content.value %}
+          {% trans "Change Your Answer" %}
+        {% else %}
+          {% trans "Answer the Question" %}
+        {% endif %}
+      </a>
+    </div>
+    {% endif %}
     <div class="btn-group cp">
       {% if user == question.author and not answers %}
       <a class="edit-question btn btn-action" href="{% url 'edit_question' question.unislug %}"
@@ -37,15 +48,6 @@
          title="{% trans "I Don't Want an Answer" %}">
         <i class="icon-thumbs-down"></i>
       </a>
-      {% if can_answer %}
-      <a class="btn btn-success btn-large" href="#add_answer_modal" data-toggle="modal">
-        {% if my_answer_form.content.value %}
-          {% trans "Change Your Answer" %}
-        {% else %}
-          {% trans "Answer the Question" %}
-        {% endif %}
-      </a>
-      {% endif %}
       {% if question|can_delete:user %}
       <a class="btn btn-danger" href="#remove-question-{{ question.id }}" data-toggle="modal"
          title="{% trans "Delete Question" %}">


### PR DESCRIPTION
Since this button still has text on it and it's bigger, it looks really
bad when it's in the same button group as the iconified buttons.
Moved it outside the group, so it now appears to its left.
